### PR TITLE
Made server return an array of stats per peer, regardless of their count

### DIFF
--- a/single-page/server.js
+++ b/single-page/server.js
@@ -776,11 +776,11 @@ async function updatePeerStats() {
       if (!stats || !roomState.peers[peerId]) {
         continue;
       }
-      roomState.peers[peerId].stats[consumer.id] = {
+      roomState.peers[peerId].stats[consumer.id] = [{
         bitrate: stats.bitrate,
         fractionLost: stats.fractionLost,
         score: stats.score
-      }
+      }]
     } catch (e) {
       warn('error while updating consumer stats', e);
     }


### PR DESCRIPTION
This makes it easier to write type-safe clients that expect either an object or an array, but not both.